### PR TITLE
chore: Replace import for api stack gateway id with ssm resolve

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -28,6 +28,9 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
+  ApiStackName:
+    Type: String
+    Default: toy-cri-api
 
 Conditions:
   IsNotDevelopment: !Or
@@ -272,8 +275,7 @@ Resources:
             - Name: API_BASE_URL
               Value: !Sub
                 - "https://${APIGatewayId}-${VpceId}.execute-api.${AWS::Region}.amazonaws.com/${Environment}"
-                - APIGatewayId:
-                    Fn::ImportValue: toy-cri-api-PrivateToyApiGatewayId
+                - APIGatewayId: !Sub "{{resolve:ssm:/${ApiStackName}/PrivateApiGatewayId}}"
                   VpceId:
                     Fn::ImportValue: cri-vpc-ExecuteApiGatewayEndpointId
                   Environment: !Ref Environment


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
- Use resolve SSM instead of import

### What changed

- Parameter added for api stack name
- ssm resolve function used instead of import

### Why did it change

- Enables the changing of the api gateway without tearing down multiple other stacks in the environment. 

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
