### PR TITLE
BAU: Added `*` to Dynatrace Secret ARN

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -130,14 +126,14 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "bc794cebe558155f13aba1743457f906cb8bd7a9",
+        "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
         "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "8a874a3fb21250a2518578da2c545eee007741ce",
+        "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
         "line_number": 398
       },
@@ -147,8 +143,22 @@
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
         "line_number": 403
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "bc794cebe558155f13aba1743457f906cb8bd7a9",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "8a874a3fb21250a2518578da2c545eee007741ce",
+        "is_verified": false,
+        "line_number": 451
       }
     ]
   },
-  "generated_at": "2023-11-23T04:11:49Z"
+  "generated_at": "2023-12-19T10:55:52Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -394,8 +394,8 @@ Resources:
                 Action:
                   - "secretsmanager:GetSecretValue" #pragma: allowlist secret
                 Resource:
-                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
-                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables*"
+                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables*"
               - Effect: Allow
                 Action:
                   - "secretsmanager:ListSecrets" #pragma: allowlist secret


### PR DESCRIPTION
## Proposed changes

### What changed

template.yaml added * to the dynatrace secret

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Causes the pipeline deployment to fail because secrets are always prefixed with a random set of digits at the end.

