### PR TITLE
IPS-493: Update post-merge workflow to use devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/post-merge-deploy.yaml
+++ b/.github/workflows/post-merge-deploy.yaml
@@ -21,6 +21,10 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@v3
         with:
@@ -28,12 +32,16 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+
       - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: alphagov/di-devplatform-upload-action-ecr@1.0.3
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
         with:
           artifact-bucket-name: ${{ secrets[format('{0}_{1}', matrix.environment, 'ARTIFACT_BUCKET')] }}
           container-sign-kms-key-arn: ${{ secrets[format('{0}_{1}', matrix.environment, 'CONTAINER_SIGN_KMS_KEY')] }}
           working-directory: .
+          docker-build-path: .
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets[format('{0}_{1}', matrix.environment, 'GH_ACTIONS_ROLE_ARN')] }}
           ecr-repo-name: ${{ secrets[format('{0}_{1}', matrix.environment, 'ECR_REPOSITORY')] }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 coverage/
 
 .env
+
+# OS generated files
+**/.DS_Store


### PR DESCRIPTION
### What changed

- Updated post-merge workflow to use devplatform-upload-action-ecr@1.2.0
- Updated .gitignore

### Why did it change

- Required for canary deployments across Identity

### Issue tracking
- [IPS-493](https://govukverify.atlassian.net/browse/IPS-493)
- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)

## Checklists

### Evidence
- Image successfully pushed to dev, with commit tag:
https://github.com/govuk-one-login/ipv-cri-toy-front/actions/runs/7932079785/job/21657700310

![Screenshot 2024-02-16 at 15 02 47](https://github.com/govuk-one-login/ipv-cri-toy-front/assets/153090281/bbc91e3b-aea7-4ee0-942d-d4086faf6681)

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-493]: https://govukverify.atlassian.net/browse/IPS-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ